### PR TITLE
Clean up autocorrelation function and mcu

### DIFF
--- a/mcu/mcu.ino
+++ b/mcu/mcu.ino
@@ -9,7 +9,6 @@
 Preferences preferences;
 double desired_freq;
 double sample_freq;
-int count = 0;
 short rawData[LENGTH];
 
 /*
@@ -39,7 +38,7 @@ void adc_setup(){
 
 	adc_digi_pattern_config_t adc_pattern;
 	adc_pattern.atten = ADC_ATTEN_DB_0;
-	adc_pattern.channel = ADC1_CHANNEL_6;
+	adc_pattern.channel = ADC1_CHANNEL_4;
 	adc_pattern.unit = ADC_UNIT_1;
 	adc_pattern.bit_width = 12;
 
@@ -89,10 +88,7 @@ void loop() {
 
     desired_freq = get_tuning();
     double current_frequency = measureFrequency(sample_freq);
-    // Serial.printf("desired freq: %f\r\n", desired_freq);
+    Serial.printf("current frequency: %d, desired freq: %f\r\n", current_frequency, desired_freq);
 
-	Serial.println(current_frequency);
-
-    // pid(current_frequency);
-    count = 0;
+    pid(current_frequency);
 }

--- a/mcu/mcu.ino
+++ b/mcu/mcu.ino
@@ -7,12 +7,19 @@
 #define LENGTH 4000
 
 Preferences preferences;
-double tunings[6] = {82.41, 110.00, 146.83, 196.00, 246.94, 329.63};
-int string_number;
 double desired_freq;
 double sample_freq;
 int count = 0;
 short rawData[LENGTH];
+
+/*
+ * Indices for string numbers are as follows:
+ * E2 A2 D3 G3 B3 E4
+ * 0  1  2  3  4  5
+ */
+
+double tunings[6] = {82.41, 110.00, 146.83, 196.00, 246.94, 329.63};
+int string_number;
 
 double get_tuning(){
 	preferences.begin(DEVICE_NAME, true);
@@ -80,6 +87,7 @@ void loop() {
 
     double prev_freq = desired_freq;
 
+    desired_freq = get_tuning();
     double current_frequency = measureFrequency(sample_freq);
     // Serial.printf("desired freq: %f\r\n", desired_freq);
 


### PR DESCRIPTION
Clean up `Autocorrelation` file and `mcu.ino` file.
- Remove `max_buffer` and `min_buffer` functions as our amplifier circuit now is able to deliver a more clean signal.
- Add comments to the autocorrelation function for readability and explanation